### PR TITLE
Custom notes text

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -17,6 +17,6 @@ class Admin::SettingsController < Admin::BaseController
   private
 
   def admin_settings_params
-    params.require(:admin_settings).permit(:name, :url_identifier, :auto_confirm_visits, :notes_enabled)
+    params.require(:admin_settings).permit(:name, :url_identifier, :auto_confirm_visits, :notes_enabled, :notes_text)
   end
 end

--- a/app/forms/admin/settings_form.rb
+++ b/app/forms/admin/settings_form.rb
@@ -1,6 +1,6 @@
 class Admin::SettingsForm
   include ActiveModel::Model
-  attr_reader :object, :params, :name, :url_identifier, :auto_confirm_visits, :notes_enabled
+  attr_reader :object, :params, :name, :url_identifier, :auto_confirm_visits, :notes_enabled, :notes_text
 
   delegate :new_record?, :persisted?, to: :object
 
@@ -14,16 +14,13 @@ class Admin::SettingsForm
     @url_identifier = params[:url_identifier] || object.url_identifier
     @auto_confirm_visits = params[:auto_confirm_visits] || object.auto_confirm_visits
     @notes_enabled = params[:notes_enabled] || object.notes_enabled
+    @notes_text = params[:notes_text] || object.notes_text
   end
 
   def save
     return unless valid?
 
-    object.name = name
-    object.url_identifier = url_identifier
-    object.auto_confirm_visits = auto_confirm_visits
-    object.notes_enabled = notes_enabled
-
+    copy_attribute_values
     object.save || copy_error_messages
   end
 
@@ -40,5 +37,13 @@ class Admin::SettingsForm
   def copy_error_messages
     errors.copy!(object.errors)
     false
+  end
+
+  def copy_attribute_values
+    object.name = name
+    object.url_identifier = url_identifier
+    object.auto_confirm_visits = auto_confirm_visits
+    object.notes_enabled = notes_enabled
+    object.notes_text = notes_text
   end
 end

--- a/app/javascript/css/application.css
+++ b/app/javascript/css/application.css
@@ -17,7 +17,7 @@ label {
   @apply block;
 }
 
-input, select {
+input, select, textarea {
   @apply py-3 px-2;
 }
 

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -34,16 +34,25 @@
           %b QR code changes
           if you change the URL identifier.
 
-    .my-8
+    .my-16
       = f.label :auto_confirm_visits, 'Auto-confirm visits', class: 'label'
       = f.check_box :auto_confirm_visits, class: 'input-text'
       .text-gray-500.text-xs.mt-1
         When enabled, visits are automatically confirmed.
 
-    .my-8
+    .mt-8.mb-4
       = f.label :notes_enabled, "Show 'Notes' field", class: 'label'
       = f.check_box :notes_enabled, class: 'input-text'
       .text-gray-500.text-xs.mt-1
+        Use this field if you need additional information from your visitors.
+
+    .mt-4.mb-8
+      = f.label :notes_text, 'Notes text', class: 'label'
+      = f.text_area :notes_text, class: 'input-text'
+      .text-gray-500.text-xs.mt-1
+        This text will be shown below the "Notes" field.
+        %br
+        Describe what kind of information you are asking for.
 
     .actions.my-10
       = f.submit 'Edit settings', class: 'input-submit'

--- a/app/views/visits/_form.html.haml
+++ b/app/views/visits/_form.html.haml
@@ -20,8 +20,8 @@
         .mb-8
           = f.label :notes, class: 'label'
           = f.text_field :notes, placeholder: 'optional', class: 'input-text w-full'
-          .mt-1.text-gray-500.text-xs Use this field as indicated by the host.
-
+          .mt-1.text-gray-500.text-xs.notes-text
+            = visit_form.object.host.notes_text.presence || 'Use this field as indicated by the host.'
 
       .actions.mt-10
-        = f.submit 'Submit my contact data', class: "input-submit"
+        = f.submit 'Submit my contact data', class: "input-submit w-full"

--- a/db/migrate/20201006124511_add_notes_text_to_host.rb
+++ b/db/migrate/20201006124511_add_notes_text_to_host.rb
@@ -1,0 +1,5 @@
+class AddNotesTextToHost < ActiveRecord::Migration[6.0]
+  def change
+    add_column :hosts, :notes_text, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_06_074436) do
+ActiveRecord::Schema.define(version: 2020_10_06_124511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2020_10_06_074436) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "auto_confirm_visits", default: false, null: false
     t.boolean "notes_enabled", default: true, null: false
+    t.string "notes_text"
     t.index ["email"], name: "index_hosts_on_email", unique: true
     t.index ["name"], name: "index_hosts_on_name", unique: true
     t.index ["reset_password_token"], name: "index_hosts_on_reset_password_token", unique: true

--- a/test/fixtures/hosts.yml
+++ b/test/fixtures/hosts.yml
@@ -8,6 +8,7 @@ cafe:
   name: 'Cafe Perfetto'
   url_identifier: 'cafe'
   email: 'host@perfetto.cafe'
+  notes_text: 'Please provide table number'
 
 cinema:
   <<: *DEFAULTS

--- a/test/system/admin/settings_test.rb
+++ b/test/system/admin/settings_test.rb
@@ -80,4 +80,16 @@ class Admin::SettingsTest < ApplicationSystemTestCase
       click_on 'Edit settings'
     end
   end
+
+  test 'admin writes custom notes text' do
+    sign_in hosts(:cafe)
+
+    click_on 'Account settings'
+
+    assert_changes -> { find_field('Notes text').value }, from: '', to: 'Provide the table number' do
+      fill_in 'Notes text', with: 'Provide the table number'
+      click_on 'Edit settings'
+      refresh
+    end
+  end
 end

--- a/test/system/admin/settings_test.rb
+++ b/test/system/admin/settings_test.rb
@@ -84,6 +84,10 @@ class Admin::SettingsTest < ApplicationSystemTestCase
   test 'admin writes custom notes text' do
     sign_in hosts(:cafe)
 
+    host = hosts(:cafe)
+
+    host.update(notes_text: '')
+
     click_on 'Account settings'
 
     assert_changes -> { find_field('Notes text').value }, from: '', to: 'Provide the table number' do

--- a/test/system/visits_test.rb
+++ b/test/system/visits_test.rb
@@ -88,6 +88,7 @@ class VisitsTest < ApplicationSystemTestCase
 
     visit visit_path(host_url_identifier: 'cafe')
     assert has_field?('Notes'), 'Notes should be displayed'
+    assert_selector '.notes-text', text: 'Please provide table number'
 
     host.update(notes_enabled: false)
 


### PR DESCRIPTION
Hosts can provide a custom notes text which will be displayed beneath the "Notes" input field where the visitor enters their data.