### PR TITLE
restructure css files to improve compile time

### DIFF
--- a/app/javascript/css/components/global.css
+++ b/app/javascript/css/components/global.css
@@ -1,6 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-
 body {
   @apply bg-transparent;
 }
@@ -80,5 +77,3 @@ ol {
 .field_with_errors {
   @apply w-full;
 }
-
-@import "tailwindcss/utilities";

--- a/app/javascript/css/tw_base.css
+++ b/app/javascript/css/tw_base.css
@@ -1,0 +1,1 @@
+@import "tailwindcss/base";

--- a/app/javascript/css/tw_components.css
+++ b/app/javascript/css/tw_components.css
@@ -1,0 +1,2 @@
+@import "tailwindcss/components";
+@import "./components/global.css";

--- a/app/javascript/css/tw_utilities.css
+++ b/app/javascript/css/tw_utilities.css
@@ -1,0 +1,1 @@
+@import "tailwindcss/utilities";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,11 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("css/application.css");
+
+require("css/tw_base.css");
+require("css/tw_components.css");
+require("css/tw_utilities.css");
+
 require("channels");
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,14 +1,5 @@
 module.exports = {
   plugins: [
     require('tailwindcss'),
-    require('autoprefixer'),
-    require('postcss-import'),
-    require('postcss-flexbugs-fixes'),
-    require('postcss-preset-env')({
-      autoprefixer: {
-        flexbox: 'no-2009'
-      },
-      stage: 3
-    })
-  ]
+    require('autoprefixer')  ]
 }


### PR DESCRIPTION
(https://nystudio107.com/blog/speeding-up-tailwind-css-builds)

Apparently splitting tailwinds base, components and utility into individual files and loading them seperately speeds up compilation time significantly.

In this case the compilation time went from 5s down to 0.3s.